### PR TITLE
Fixing errors in shaders with half2 type declarations

### DIFF
--- a/Assets/TransitionKit/transitions/shaders/Doorway.shader
+++ b/Assets/TransitionKit/transitions/shaders/Doorway.shader
@@ -50,8 +50,8 @@ fixed4 frag( v2f_img i ) : COLOR
 	if( _Direction == 1 )
 		_Progress = _Progress * -1.0;
 
-	half2 pfr = half2( -1.0 );
-	half2 pto = half2( -1.0 );
+	half2 pfr = half2( -1.0, -1.0 );
+	half2 pto = half2( -1.0, -1.0 );
 
 	float middleSlit = 2.0 * abs( i.uv.x - 0.5 ) - _Progress;
 	if( middleSlit > 0.0 )

--- a/Assets/TransitionKit/transitions/shaders/Ripple.shader
+++ b/Assets/TransitionKit/transitions/shaders/Ripple.shader
@@ -33,7 +33,7 @@ uniform float _Speed;
 
 fixed4 frag( v2f_img i ) : COLOR
 {
-	half2 dir = i.uv - half2( 0.5 );
+	half2 dir = i.uv - half2( 0.5, 0.5 );
 	float dist = length( dir );
 	half2 offset = dir * ( sin( _Time.x * dist * _Amplitude - _Progress * _Speed ) + 0.5 ) / 30.0;
 


### PR DESCRIPTION
I noticed when I tried to run the examples that I was getting shader errors on a Mac, turns out you need to be explicit with the half2 type declarations in the shaders to keep it happy.
